### PR TITLE
Update Project group id to a one independent of MLH hackathon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+
+# compiled object
+target/

--- a/timly/pom.xml
+++ b/timly/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>mlh.hackathon</groupId>
+    <groupId>io.timly</groupId>
     <artifactId>timly</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
@@ -31,7 +31,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.4</version>
                 <configuration>
-                    <mainClass>mlh.hackathon.App</mainClass>
+                    <mainClass>io.timly.App</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/timly/src/main/java/io/timly/App.java
+++ b/timly/src/main/java/io/timly/App.java
@@ -1,4 +1,4 @@
-package mlh.hackathon;
+package io.timly;
 
 import javafx.application.Application;
 import javafx.scene.Scene;

--- a/timly/src/main/java/io/timly/MainWin.java
+++ b/timly/src/main/java/io/timly/MainWin.java
@@ -1,4 +1,4 @@
-package mlh.hackathon;
+package io.timly;
 
 import javafx.scene.Scene;
 import javafx.scene.control.Label;

--- a/timly/src/main/java/io/timly/ResultsWin.java
+++ b/timly/src/main/java/io/timly/ResultsWin.java
@@ -1,4 +1,4 @@
-package mlh.hackathon;
+package io.timly;
 
 import javafx.scene.Scene;
 import javafx.scene.control.Label;

--- a/timly/src/main/java/io/timly/Time.java
+++ b/timly/src/main/java/io/timly/Time.java
@@ -1,4 +1,4 @@
-package mlh.hackathon;
+package io.timly;
 
 public class Time {
     

--- a/timly/src/main/java/module-info.java
+++ b/timly/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module mlh.hackathon {
+module io.timly {
     requires javafx.controls;
-    exports mlh.hackathon;
+    exports io.timly;
 }


### PR DESCRIPTION
This PR updates the project group id within the pom.xml file, the manifest file, and all other referenced files.
It also adds the generated target directory to the .gitignore file.

fixes #3 